### PR TITLE
Fixed navbar to be easier to navigate

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -66,6 +66,7 @@
                         <li><a href="/about/history/">History</a></li>
                         <li><a href="/about/song/">Song</a></li>
                         <li><a href="/about/constitution/">Constitution</a></li>
+                        <li><a href="/catering/info/"> Catering  </a></li>
                         <li role="separator" class="divider"></li>
                         <li><a href="{%url 'contactus' %}">Contact Us!</a></li>
                       </ul>
@@ -79,45 +80,20 @@
                         <li><a href="/recruitment/create_account"> Mailing List and Meals </a></li>
                      </ul>
                     </li>
-                    {% if student %}
-                        <li class="dropdown">
-                          <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"> Club <span class="caret"></span></a>
-                          <ul class="dropdown-menu">
-                            <li><a href="{%url 'weekly_menu' %}"> Menu </a></li>
-                            <li><a href="{%url 'events_list' %}"> Events </a></li>
-                            <li><a href="/catering/info/"> Catering  </a></li>
-                         </ul>
-                        </li>
 
-                        
-                        <li class="dropdown">
-                          <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"> People <span class="caret"></span></a>
-                          <ul class="dropdown-menu">
-                            <li><a href="{%url 'faceboard' %}"> Faceboard </a></li>
-                            <li><a href="{%url 'officer_list' %}"> Officers </a></li>
-                            <li><a href="{%url 'staff_list' %}"> Staff </a></li>
-                         </ul>
-                        </li>
-
-                   {% else %}
-
-                        <li class="dropdown">
-                          <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"> People <span class="caret"></span></a>
-                          <ul class="dropdown-menu">
-                            <li><a href="{%url 'faceboard' %}"> Faceboard </a></li>
-                            <li><a href="{%url 'officer_list' %}"> Officers </a></li>
-                            <li><a href="{%url 'staff_list' %}"> Staff </a></li>
-                         </ul>
-                        </li>
-                        
-                        <li><a href="{%url 'weekly_menu' %}"> Menu </a></li>
-                        <li><a href="{%url 'events_list' %}"> Events </a></li>
-                        <li><a href="{%url 'catering' %}"> Catering  </a></li>
-                   {% endif %}
+					<li class="dropdown">
+					  <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"> People <span class="caret"></span></a>
+					  <ul class="dropdown-menu">
+						<li><a href="{%url 'faceboard' %}"> Faceboard </a></li>
+						<li><a href="{%url 'officer_list' %}"> Officers </a></li>
+						<li><a href="{%url 'staff_list' %}"> Staff </a></li>
+					 </ul>
+					</li>
 
 
+					<li><a href="{%url 'weekly_menu' %}"> Menu </a></li>
 
-
+					<li><a href="{%url 'events_list' %}"> Events </a></li>
                     
 
                   {% if prospective %}
@@ -134,18 +110,6 @@
                   </li>
                   {% endif %}
 
-                  {% if member %}
-                  <li class="dropdown">
-                    <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Member <span class="caret"></span></a>
-                    <ul class="dropdown-menu">
-                      <li><a href="{%url 'profile' %}">Profile</a></li>
-                      <li><a href="{%url 'feedback' %}">Anonymous Feedback</a></li>
-                      <li><a href="{%url 'faceboard' %}"> Faceboard </a></li>
-                      <li><a href="{%url 'officer_list' %}"> Officers </a></li>
-                    </ul>
-                  </li>
-                  {% endif %}
-                  
                   {% if officer %}
                   <li class="dropdown">
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Officer <span class="caret"></span></a>
@@ -183,7 +147,9 @@
                       {% if member or prospective %}
                       <li><a href="{%url 'profile' %}">Profile</a></li>
                       {% endif %}
-                      
+                      {% if member %} 
+                      <li><a href="{%url 'feedback' %}">Anonymous Feedback</a></li>
+					  {% endif %}
                       <li><a href="{%url 'logout' %}">Logout</a></li>
                     </ul>
                   </li>


### PR DESCRIPTION
Fixes the navbar so that `club` section is gone with new direct links to menu and events and catering now under the `about` section. The `member` dropdown is also gone because the only unique link was to the Anonymous Feedback page and I put that under user on the top right.
