### PR TITLE
Allow response poster to exclude username from post

### DIFF
--- a/feedback/admin.py
+++ b/feedback/admin.py
@@ -5,7 +5,7 @@ from django.contrib import admin
 from feedback.models import FeedbackResponse
 
 class FeedbackResponseAdmin(admin.ModelAdmin):
-  exclude = ("responded_by",)
+  readonly_fields = ("responded_by", "response_time")
 
   def save_model(self, request, obj, form, change):
     obj.responded_by = request.user

--- a/feedback/migrations/0002_feedbackresponse_display_user.py
+++ b/feedback/migrations/0002_feedbackresponse_display_user.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('feedback', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='feedbackresponse',
+            name='display_user',
+            field=models.BooleanField(default=True),
+            preserve_default=True,
+        ),
+    ]

--- a/feedback/migrations/0003_feedbackresponse_visible.py
+++ b/feedback/migrations/0003_feedbackresponse_visible.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('feedback', '0002_feedbackresponse_display_user'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='feedbackresponse',
+            name='visible',
+            field=models.BooleanField(default=True),
+            preserve_default=True,
+        ),
+    ]

--- a/feedback/models.py
+++ b/feedback/models.py
@@ -11,8 +11,8 @@ class FeedbackResponse(models.Model):
   responded_by = models.ForeignKey(User)
   response_time = models.DateTimeField(auto_now_add=True)
 
-  def __repr__(self):
-    return '({}) (by {} at {})'.format(
-      self.feedback_description,
-      self.responded_by.username,
-      self.response_time.isoformat())
+  def __str__(self):
+    return '{desc} (by {poster} at {t})'.format(
+      desc=self.feedback_description,
+      poster=self.responded_by.username,
+      t=self.response_time.isoformat())

--- a/feedback/models.py
+++ b/feedback/models.py
@@ -8,6 +8,7 @@ class FeedbackResponse(models.Model):
   feedback_description = models.TextField()
   response = models.TextField()
   display_user = models.BooleanField(default=True)
+  visible = models.BooleanField(default=True)
 
   responded_by = models.ForeignKey(User)
   response_time = models.DateTimeField(auto_now_add=True)

--- a/feedback/models.py
+++ b/feedback/models.py
@@ -10,3 +10,9 @@ class FeedbackResponse(models.Model):
 
   responded_by = models.ForeignKey(User)
   response_time = models.DateTimeField(auto_now_add=True)
+
+  def __repr__(self):
+    return '({}) (by {} at {})'.format(
+      self.feedback_description,
+      self.responded_by.username,
+      self.response_time.isoformat())

--- a/feedback/models.py
+++ b/feedback/models.py
@@ -7,6 +7,7 @@ from django.contrib.auth.models import User
 class FeedbackResponse(models.Model):
   feedback_description = models.TextField()
   response = models.TextField()
+  display_user = models.BooleanField(default=True)
 
   responded_by = models.ForeignKey(User)
   response_time = models.DateTimeField(auto_now_add=True)

--- a/feedback/views.py
+++ b/feedback/views.py
@@ -59,8 +59,9 @@ def responses(request):
     today = datetime.datetime.today()
     start_time = today - datetime.timedelta(days=14)
 
-    responses_available = FeedbackResponse.objects.filter(
-      response_time__gte=start_time).order_by('-response_time')
+    responses_available = (FeedbackResponse.objects
+      .filter(response_time__gte=start_time, visible=True)
+      .order_by('-response_time'))
 
     return render(request, 'feedback/responses.html', {
        'responses': responses_available,

--- a/feedback/views.py
+++ b/feedback/views.py
@@ -55,12 +55,12 @@ def thanks(request):
 
 @permissions.member
 def responses(request):
+    # Display responses in the past two weeks.
     today = datetime.datetime.today()
-    # get the start of the week
-    week_start = today - datetime.timedelta(days=today.isoweekday() % 7)
+    start_time = today - datetime.timedelta(days=14)
 
     responses_available = FeedbackResponse.objects.filter(
-      response_time__gte=week_start).order_by('-response_time')
+      response_time__gte=start_time).order_by('-response_time')
 
     return render(request, 'feedback/responses.html', {
        'responses': responses_available,

--- a/templates/base.html
+++ b/templates/base.html
@@ -166,6 +166,7 @@
                       {% endif %}
                       {% if member %}
                       <li><a href="{%url 'feedback' %}">Anonymous Feedback</a></li>
+                      <li><a href="{%url 'feedback.views.responses' %}">Anonymous Feedback Responses</a></li>
 					  {% endif %}
                       <li><a href="{%url 'logout' %}">Logout</a></li>
                     </ul>
@@ -193,7 +194,7 @@
       <div class="container">
         <div class="col-md-6 text-left text-muted">Created by members of the Princeton Charter Club</div>
           <div class="col-md-6 text-right text-muted">
-              © Princeton Charter Club 2016
+              © Princeton Charter Club 2018
           </div>
       </div>
     </footer>

--- a/templates/feedback/responses.html
+++ b/templates/feedback/responses.html
@@ -23,7 +23,11 @@
   <br/>
   <p><b>Feedback Description</b>: {{resp.feedback_description}}</p>
   <p><b>Response</b>: {{resp.response}}</p>
-  <p><b>Posted by</b>: {{resp.responded_by.username}} ({{resp.response_time | naturaltime}})</p>
+  <p><b>Posted by</b>:
+    {% if resp.display_user %} {{resp.responded_by.username}}
+    {% else %} Charter Officers
+    {% endif %}
+    ({{resp.response_time | naturaltime}})</p>
 </div>
 {% endfor %}
 

--- a/templates/feedback/responses.html
+++ b/templates/feedback/responses.html
@@ -13,7 +13,7 @@
 
 <div class="row">
   <p> Responses to anonymous feedback, as requested by the sender, are shown
-    below. </p>
+    below. Only the responses from the past two weeks are shown. </p>
 </div>
 
 <h3>Responses</h3>


### PR DESCRIPTION
Generally, this is for when the post is meant to come from the entirety of the officer corps as opposed to relevant for a single officer. So, this allows for that.

In addition, all the feedback from the past 14 days is displayed as opposed to just in the past calendar week.