### PR TITLE
Use heroku-18 stack

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,6 +2,7 @@
   "name": "Charter-Website",
   "scripts": {
   },
+  "stack": "heroku-18",
   "env": {
     "AWS_ACCESS_KEY_ID": {
       "required": true


### PR DESCRIPTION
Cedar-14 is deprecated and resulting in warnings, whereas Heroku-18 will be supported for another 3 years: https://devcenter.heroku.com/articles/stack#stack-support-details.